### PR TITLE
v0.2.1 hotfix

### DIFF
--- a/depends/packages/libgmp.mk
+++ b/depends/packages/libgmp.mk
@@ -1,11 +1,11 @@
 package=libgmp
 
 ifeq ($(host_os),mingw32)
-$(package)_download_path=https://github.com/joshuayabut/$(package)/archive
+$(package)_download_path=https://github.com/radix42/$(package)/archive
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=193836c1acc9dc00fe2521205d7bbe1ba13263f6cbef6f02584bf6f8b34b108f
-$(package)_git_commit=053c03b1cab347671d936f43ef66b48ab5e380ee
+$(package)_sha256_hash=7082f9363b3b3eb004219fc50c7d28f2271a2674bea917739724c94f1b26c7cc
+$(package)_git_commit=42ba95387cdfd67399f7aac52fddb8d6e1258ee6
 $(package)_dependencies=
 $(package)_config_opts=--enable-cxx --disable-shared
 else ifeq ($(build_os),darwin)

--- a/depends/packages/libgmp.mk
+++ b/depends/packages/libgmp.mk
@@ -4,7 +4,7 @@ ifeq ($(host_os),mingw32)
 $(package)_download_path=https://github.com/radix42/$(package)/archive
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=7082f9363b3b3eb004219fc50c7d28f2271a2674bea917739724c94f1b26c7cc
+$(package)_sha256_hash=67df06ed50f288bd7b1ec6907973684fb7cf1196f2cb368b59d423e42b065e40
 $(package)_git_commit=42ba95387cdfd67399f7aac52fddb8d6e1258ee6
 $(package)_dependencies=
 $(package)_config_opts=--enable-cxx --disable-shared

--- a/src/cc/agreements.cpp
+++ b/src/cc/agreements.cpp
@@ -1286,9 +1286,15 @@ UniValue AgreementCreate(const CPubKey& pk,uint64_t txfee,CPubKey destpub,std::s
 		txfee = CC_TXFEE;
 	mypk = pk.IsValid() ? pk : pubkey2pk(Mypubkey());
 
-	// Checking passed parameters.
+	// Checking pubkeys.
 	if (!(destpub.IsFullyValid()))
 		CCERR_RESULT("agreementscc", CCLOG_INFO, stream << "Destination pubkey must be valid");
+
+	// mypk and destpub cannot be the same.
+	else if (mypk == destpub)
+		CCERR_RESULT("agreementscc", CCLOG_INFO, stream << "Source pubkey and destination pubkey cannot be the same");
+
+	// Checking other passed parameters.
 	if (agreementname.empty() || agreementname.size() > 64)
 		CCERR_RESULT("agreementscc", CCLOG_INFO, stream << "Agreement name cannot be empty and must be up to 64 characters");
 	if (agreementhash == zeroid)
@@ -1301,6 +1307,10 @@ UniValue AgreementCreate(const CPubKey& pk,uint64_t txfee,CPubKey destpub,std::s
 	// Check arbitrator and disputefee.
 	if (arbitratorpub.IsFullyValid())
 	{
+		// If arbitratorpub is defined, it can't be the same as mypk or destpub.
+		if (arbitratorpub == mypk || arbitratorpub == destpub)
+			CCERR_RESULT("agreementscc", CCLOG_INFO, stream << "Arbitrator pubkey cannot be the same as source or destination pubkey");
+
 		if (disputefee < CC_MARKER_VALUE)
 			CCERR_RESULT("agreementscc", CCLOG_INFO, stream << "Required dispute fee must be at least "+std::to_string(CC_MARKER_VALUE)+" satoshis when arbitrator is defined");
 	}


### PR DESCRIPTION
Changelog:

- Added pubkey check in agreementcreate to make sure offeror/signer/arbitrator cannot be the same pubkey
- Fetch libgmp for windows from another repo when compiling windows builds